### PR TITLE
fix(hermes/UX): hide internal retrieval tools from user-facing chat (#814)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -23,6 +23,35 @@ from __future__ import annotations
 
 from typing import Any
 
+
+
+# ---------------------------------------------------------------------------
+# Internal/retrieval tools — hidden from user-facing chat by default
+# ---------------------------------------------------------------------------
+# These are agent-internal retrieval and search tools that produce no
+# user-visible output.  Showing them in chat adds noise without value.
+# The "internal" tool_progress mode filters these out; "all" and "verbose"
+# modes still show them.  See toryx-private#814.
+_INTERNAL_TOOLS: frozenset[str] = frozenset({
+    "session_search",
+    "search_files",
+    "skill_view",
+    "skills_list",
+    "memory",
+    "recall_search",
+    "recall",
+    "web_search",
+    "web_extract",
+    "read_file",
+    "list_files",
+    "vision_analyze",
+})
+
+
+def is_internal_tool(tool_name: str) -> bool:
+    """Return True if *tool_name* is an internal/retrieval tool."""
+    return tool_name in _INTERNAL_TOOLS
+
 # ---------------------------------------------------------------------------
 # Overrideable display settings and their global defaults
 # ---------------------------------------------------------------------------
@@ -31,7 +60,7 @@ from typing import Any
 # and don't participate in per-platform resolution.
 
 _GLOBAL_DEFAULTS: dict[str, Any] = {
-    "tool_progress": "all",
+    "tool_progress": "internal",
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
@@ -46,7 +75,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
 # Tier 4 (minimal): Batch/non-interactive delivery
 
 _TIER_HIGH = {
-    "tool_progress": "all",
+    "tool_progress": "internal",
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,  # follow global

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6281,9 +6281,10 @@ class GatewayRunner:
             )
 
         # --- cycle mode (per-platform) ----------------------------------------
-        cycle = ["off", "new", "all", "verbose"]
+        cycle = ["off", "internal", "new", "all", "verbose"]
         descriptions = {
             "off": "⚙️ Tool progress: **OFF** — no tool activity shown.",
+            "internal": "⚙️ Tool progress: **INTERNAL** — hides retrieval/search tools, shows a collapsed summary (default for Telegram).",
             "new": "⚙️ Tool progress: **NEW** — shown when tool changes (preview length: `display.tool_preview_length`, default 40).",
             "all": "⚙️ Tool progress: **ALL** — every tool call shown (preview length: `display.tool_preview_length`, default 40).",
             "verbose": "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments.",
@@ -6291,7 +6292,7 @@ class GatewayRunner:
 
         # Read current effective mode for this platform via the resolver
         from gateway.display_config import resolve_display_setting
-        current = resolve_display_setting(user_config, platform_key, "tool_progress", "all")
+        current = resolve_display_setting(user_config, platform_key, "tool_progress", "internal")
         if current not in cycle:
             current = "all"
         idx = (cycle.index(current) + 1) % len(cycle)
@@ -8440,6 +8441,8 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        _internal_counter = [0]  # Count of suppressed internal tool calls
+        last_internal_tool = [None]  # Last internal tool name (for collapsed summary)
         
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
@@ -8448,6 +8451,16 @@ class GatewayRunner:
 
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in ("tool.started",):
+                return
+
+            # Filter internal/retrieval tools from user-facing chat.
+            # "internal" mode hides them; "all" and "verbose" show everything.
+            from gateway.display_config import is_internal_tool
+            _is_internal = is_internal_tool(tool_name or "")
+            if _is_internal and progress_mode in ("internal", "new"):
+                # Count but don't display — we'll emit a collapsed summary later
+                _internal_counter[0] += 1
+                last_internal_tool[0] = tool_name
                 return
 
             # "new" mode: only report when tool changes
@@ -8647,6 +8660,18 @@ class GatewayRunner:
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
         
+        # Emit collapsed internal-tool summary before agent result.
+        # When "internal" progress mode hid retrieval/search calls, show a
+        # single line like "🔍 Searching… (3 queries)" so the user knows
+        # work happened, without the wall of individual tool traces.
+        if _internal_counter[0] > 0 and progress_queue is not None:
+            _summary_parts = []
+            if _internal_counter[0] == 1:
+                _summary_parts.append(f"🔍 {last_internal_tool[0] or 'searching'}…")
+            else:
+                _summary_parts.append(f"🔍 Searching… ({_internal_counter[0]} queries)")
+            progress_queue.put(_summary_parts[0])
+
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
         _hooks_ref = self.hooks


### PR DESCRIPTION
## Summary

toryx-private#807 Issue 1: Christopher echoed 9 internal retrieval tool calls as emoji lines into Telegram instead of a natural reply. This PR adds an "internal" tool-progress mode (new default for Telegram) that suppresses those and emits a single collapsed summary line.

## Changes

**`gateway/display_config.py`** (+31/-2)
- `_INTERNAL_TOOLS` frozenset: `session_search`, `search_files`, `skill_view`, `skills_list`, `memory`, `recall_search`, `recall`, `web_search`, `web_extract`, `read_file`, `list_files`, `vision_analyze`
- `is_internal_tool(tool_name)` helper
- `_GLOBAL_DEFAULTS["tool_progress"]`: `"all"` → `"internal"`
- `_TIER_HIGH["tool_progress"]` (Telegram tier): `"all"` → `"internal"`

**`gateway/run.py`** (+27/-2)
- Handle `tool_progress == "internal"`:
  - Track `_internal_counter` + last internal tool name
  - Suppress per-call emoji lines for internal tools
  - Emit collapsed summary: `🔍 Searching… (N queries)` so user sees progress

## Not changed

- `"all"` mode preserved for users who opt in to full trace
- `"verbose"` mode preserved
- Non-internal tools (`execute_code`, `place_stock_order`, etc.) still display normally in all modes

## Closes

- lmsanch/toryx-private#814

## Provenance note

Originally coded on Spark's live hermes-agent by an OpenCode worker. Relayed via patch from Spark → DNN because Spark's deploy key is scoped only to `lmsanch/toryx-private`. Commit content identical across both locations.