### PR TITLE
fix(gateway): suppress busy-ack to unauthorized senders + EMAIL_IGNORED_SENDERS (#716)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -416,6 +416,17 @@ class EmailAdapter(BasePlatformAdapter):
         if sender_addr == self._address.lower():
             return
 
+        # Drop senders explicitly blocklisted via EMAIL_IGNORED_SENDERS.
+        # Defense in depth against intra-fleet email loops where two
+        # gateways configured with each other as unauthorized senders
+        # ping-pong busy-ack notifications forever.
+        ignored_raw = os.getenv('EMAIL_IGNORED_SENDERS', '').strip()
+        if ignored_raw and sender_addr:
+            ignored_set = {a.strip().lower() for a in ignored_raw.split(',') if a.strip()}
+            if sender_addr.lower() in ignored_set:
+                logger.info('[Email] Ignoring blocklisted sender: %s', sender_addr)
+                return
+
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
             logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1389,6 +1389,21 @@ class GatewayRunner:
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # Auth check FIRST: unauthorized senders must never trigger an
+        # outbound reply, including the busy-ack. Without this, two
+        # gateways configured with each other's address as unauthorized
+        # can ping-pong busy-acks forever (Toryx 2026-04-19 incident:
+        # 487 emails between two MD profiles in 20 min). Internal events
+        # bypass auth as elsewhere in the codebase.
+        if not getattr(event, 'internal', False) and event.source.user_id is not None:
+            if not self._is_user_authorized(event.source):
+                logger.info(
+                    'Suppressed busy-ack to unauthorized sender %s on %s',
+                    event.source.user_id,
+                    event.source.platform.value if event.source.platform else 'unknown',
+                )
+                return True  # consume event silently
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)


### PR DESCRIPTION
## Summary

Single cherry-pick of commit `94838b32` from the downstream-tracking branch `fix/email-loop-busy-ack-auth`. That branch has been sitting with 339 upstream NousResearch pulls + this 1 real fix uncommitted to main for 4 days.

## The fix

**Gateway was sending the "⚡ Interrupting current task" busy-ack to ANY sender, including unauthorized ones.** That's how the 487-email Hilary↔Christopher loop from toryx-private#716 escalated — each unauthorized sender's busy-ack fueled the other's, because auth-check ran AFTER the reply path.

Changes:
- `gateway/run.py`: check authorization BEFORE emitting the busy-ack
- `gateway/platforms/email.py`: honor `EMAIL_IGNORED_SENDERS` env var (silently drop matching senders, no reply of any kind)

+26 lines across 2 files. Narrow, discrete, no upstream sync noise.

## Closes

- lmsanch/toryx-private#716

## Provenance

Cherry-picked from `fix/email-loop-busy-ack-auth` so the rest of that branch (upstream syncs) can be handled separately as a proper rebase decision later.