### PR TITLE
fix(tts): restore Fish Audio implementation reverted in 19098b06 (voice regression) + closes toryx-private#797

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1765,8 +1765,8 @@ class BasePlatformAdapter(ABC):
                         except OSError:
                             pass
 
-                # Send the text portion
-                if text_content:
+                # Send the text portion (skip if TTS voice was already sent for inbound voice)
+                if text_content and not _tts_path:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -275,6 +275,15 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    def _smtp_connect(self):
+        if self._smtp_port == 465:
+            smtp = smtplib.SMTP_SSL(self._smtp_host, self._smtp_port, timeout=30, context=ssl.create_default_context())
+        else:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+            smtp.starttls(context=ssl.create_default_context())
+        smtp.login(self._address, self._password)
+        return smtp
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
@@ -297,9 +306,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp = self._smtp_connect()
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -380,6 +387,8 @@ class EmailAdapter(BasePlatformAdapter):
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
+                    delivered_to = msg.get("Delivered-To", msg.get("To", self._address))
+                    recipient_addr = _extract_email_address(delivered_to) if delivered_to else self._address
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
@@ -398,6 +407,7 @@ class EmailAdapter(BasePlatformAdapter):
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
+                        "recipient_addr": recipient_addr,
                     })
             finally:
                 try:
@@ -456,6 +466,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "recipient_addr": msg_data.get("recipient_addr", self._address),
         }
 
         source = self.build_source(
@@ -507,7 +518,9 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        ctx = self._thread_context.get(to_addr, {})
+        from_addr = ctx.get("recipient_addr", self._address)
+        msg["From"] = from_addr
         msg["To"] = to_addr
 
         # Thread context for reply
@@ -528,10 +541,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._smtp_connect()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -620,10 +631,8 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._smtp_connect()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3977,6 +3977,18 @@ class GatewayRunner:
                     )
         
         # -----------------------------------------------------------------
+        # Voice input brevity — when user sends a voice message, the
+        # response will be read aloud via TTS. Keep answers concise and
+        # conversational (2-3 sentences max). No markdown, no lists.
+        # -----------------------------------------------------------------
+        if event.message_type == MessageType.VOICE:
+            context_prompt += (                "\n\n[System note: The user sent a voice message. Your reply "
+                "will be read aloud via text-to-speech. Keep it brief, "
+                "conversational, and spoken-style — 2-3 sentences max. "
+                "No markdown, no bullet lists, no code blocks. Answer as "
+                "if talking on a walkie-talkie.]"
+            )
+        # -----------------------------------------------------------------
         # Voice channel awareness — inject current voice channel state
         # into context so the agent knows who is in the channel and who
         # is speaking, without needing a separate tool call.
@@ -7460,6 +7472,7 @@ class GatewayRunner:
         in a ``finally`` block.
         """
         from gateway.session_context import set_session_vars
+        os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -7124,6 +7124,21 @@ class AIAgent:
         ]
         return api_msg
 
+
+    def _supports_reasoning_content(self) -> bool:
+        """Check if the current provider supports reasoning_content in messages.
+
+        Groq and some strict APIs reject reasoning_content. Return False
+        for providers known to not support it.
+        """
+        provider = getattr(self, 'provider_label', '') or ''
+        base_url = getattr(self, 'base_url', '') or ''
+        unsupported = ('groq', 'cerebras', 'sambanova')
+        for u in unsupported:
+            if u in provider.lower() or u in base_url.lower():
+                return False
+        return True
+
     def _should_sanitize_tool_calls(self) -> bool:
         """Determine if tool_calls need sanitization for strict APIs.
 
@@ -8790,7 +8805,8 @@ class AIAgent:
                     reasoning_text = msg.get("reasoning")
                     if reasoning_text:
                         # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
-                        api_msg["reasoning_content"] = reasoning_text
+                        if self._supports_reasoning_content():
+                            api_msg["reasoning_content"] = reasoning_text
 
                 # Remove 'reasoning' field - it's for trajectory storage only
                 # We've copied it to 'reasoning_content' for the API above

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -711,6 +711,32 @@ def _default_neutts_ref_text() -> str:
     return str(Path(__file__).parent / "neutts_samples" / "jo.txt")
 
 
+def _generate_fish_audio(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    api_key = os.getenv("FISH_AUDIO_API_KEY", tts_config.get("fish", {}).get("api_key", ""))
+    if not api_key:
+        raise RuntimeError("FISH_AUDIO_API_KEY not set")
+    voice_id = tts_config.get("fish", {}).get("voice_id", os.getenv("FISH_AUDIO_VOICE_ID", ""))
+    if not voice_id:
+        raise RuntimeError("FISH_AUDIO_VOICE_ID not set")
+    base_url = tts_config.get("fish", {}).get("base_url", "https://api.fish.audio")
+    import urllib.request
+    import json as _json
+    fish_format = "opus" if output_path.endswith(".ogg") else "mp3"
+    payload = _json.dumps({"text": text, "reference_id": voice_id, "format": fish_format}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/tts",
+        data=payload,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        audio = resp.read()
+    if not audio or len(audio) < 100:
+        raise RuntimeError("Fish Audio returned empty or tiny response")
+    with open(output_path, "wb") as f:
+        f.write(audio)
+    return output_path
+
 def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate speech using the local NeuTTS engine.
 
@@ -809,6 +835,8 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+    if not platform:
+        platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
     want_opus = (platform == "telegram")
 
     # Determine output path
@@ -820,7 +848,7 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini"):
+        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini", "fish"):
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -877,6 +905,13 @@ def text_to_speech_tool(
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
 
+        elif provider == "fish":
+            api_key = os.getenv("FISH_AUDIO_API_KEY", tts_config.get("fish", {}).get("api_key", ""))
+            if not api_key:
+                return json.dumps({"success": False, "error": "FISH_AUDIO_API_KEY not set"}, ensure_ascii=False)
+            logger.info("Generating speech with Fish Audio...")
+            _generate_fish_audio(text, file_str, tts_config)
+
         elif provider == "neutts":
             if not _check_neutts_available():
                 return json.dumps({
@@ -931,7 +966,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in ("elevenlabs", "openai", "mistral", "gemini"):
+        elif provider in ("elevenlabs", "openai", "mistral", "gemini", "fish"):
             voice_compatible = file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)


### PR DESCRIPTION
Cherry-pick of 00280b06 from feat/consult-colleague-stopgap branch (never merged). Revert in 19098b06 dropped 218 lines including _generate_fish_audio + the voice-only-reply suppression logic in base.py. Ray (new 6th MD deployed today) loaded the broken main fresh at 19:32 EDT and has been generating replies via the Edge TTS else-branch fallback — Microsoft generic voice instead of his Fish clone.

Also restores:
- Voice-only reply (suppress text when TTS audio was sent)
- SMTP port 465 support in email adapter
- Groq reasoning guard in run.py

## Permanence

TODO in follow-up PR: add CI test asserting `provider == 'fish'` branch exists in tts_tool.py, and remove the silent Edge fallback (fail-loud when provider doesn't match any known branch). This prevents future reverts from silently regressing this class again.

Closes lmsanch/toryx-private#797