### PR TITLE
feat(toryx): integrate 10 Toryx-specific commits from feat/thompson-sampling-routing (#833)

### DIFF
--- a/agent/language_hint.py
+++ b/agent/language_hint.py
@@ -1,0 +1,271 @@
+"""Deterministic language detection + response-language hint injector.
+
+Purpose
+-------
+Belt-and-suspenders companion to the SOUL-level ``## Language Mirroring``
+directive. The prompt-side directive works for stronger models but under
+context pressure (long tool outputs, KMS harvest hits, prior non-user
+turns) weaker or default-quantization models drift. A deterministic,
+code-level detector that prepends ``[RESPOND IN: <lang>]`` to the user
+turn closes that gap without requiring model strength.
+
+Design
+------
+Zero dependencies (stdlib only). Two-stage detection:
+
+1. **Unicode script fast-path.** If the message is dominated by one of
+   a small set of distinctive scripts (CJK, Hangul, Cyrillic, Arabic,
+   Devanagari, Hebrew, Thai), return the corresponding ISO code
+   immediately with high confidence.
+2. **Function-word scoring** for Latin-script text. Short, frequent
+   words are language-defining. We score the six most common Hermes
+   languages (en, es, pt, fr, de, it) by counting hits from a curated
+   function-word set. The winner needs a minimum absolute hit count
+   and a minimum margin over the runner-up.
+
+Shared concerns:
+- Minimum text length (too-short inputs are not detectable).
+- Confidence is a number in [0.0, 1.0]; callers pass ``min_confidence``.
+
+This module is intentionally small and auditable. It is not a
+replacement for a proper language model for edge cases (mixed-language
+turns, rare languages, very short messages) — for those it returns
+``(None, 0.0)`` and the caller should skip the hint.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import unicodedata
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_MIN_ALPHA_CHARS = 12
+
+_SCRIPT_RANGES = {
+    "zh": [(0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0x20000, 0x2A6DF)],
+    "ja": [(0x3040, 0x309F), (0x30A0, 0x30FF)],
+    "ko": [(0xAC00, 0xD7AF), (0x1100, 0x11FF)],
+    "ru": [(0x0400, 0x04FF)],
+    "ar": [(0x0600, 0x06FF), (0x0750, 0x077F)],
+    "hi": [(0x0900, 0x097F)],
+    "he": [(0x0590, 0x05FF)],
+    "th": [(0x0E00, 0x0E7F)],
+}
+
+_SCRIPT_DOMINANCE_RATIO = 0.30
+
+_FUNCTION_WORDS: dict[str, frozenset[str]] = {
+    "en": frozenset({
+        "the", "and", "of", "to", "in", "is", "it", "that", "for", "on",
+        "with", "as", "are", "was", "be", "this", "have", "has", "from",
+        "but", "not", "or", "an", "at", "by", "we", "you", "they", "he",
+        "she", "what", "when", "where", "which", "how", "why", "if",
+        "about", "into", "than", "then", "there", "their", "will",
+        "would", "could", "should", "can", "do", "does", "did", "been",
+    }),
+    "es": frozenset({
+        "el", "la", "los", "las", "de", "del", "y", "que", "en", "un",
+        "una", "es", "por", "con", "para", "no", "se", "su", "al", "lo",
+        "mi", "tu", "pero", "más", "como", "este", "esta", "estos",
+        "estas", "eso", "son", "fue", "ser", "está", "están", "qué",
+        "cuál", "dónde", "cómo", "porqué", "cuando", "también",
+        "sobre", "porque", "hasta", "desde",
+    }),
+    "pt": frozenset({
+        "o", "a", "os", "as", "de", "do", "da", "dos", "das", "e", "que",
+        "em", "um", "uma", "é", "por", "com", "para", "não", "se", "mas",
+        "mais", "como", "este", "esta", "estes", "estas", "isso", "são",
+        "foi", "ser", "está", "estão", "qual", "onde", "quando", "porque",
+        "também", "sobre", "até", "pelo", "pela", "você", "eu",
+    }),
+    "fr": frozenset({
+        "le", "la", "les", "de", "des", "du", "et", "que", "en", "un",
+        "une", "est", "par", "avec", "pour", "ne", "pas", "se", "son",
+        "sa", "ses", "au", "aux", "mais", "plus", "comme", "ce", "cette",
+        "ces", "sont", "a", "à", "être", "où", "quand", "comment",
+        "pourquoi", "aussi", "sur", "parce", "jusqu", "depuis", "vous",
+    }),
+    "de": frozenset({
+        "der", "die", "das", "den", "dem", "des", "und", "ist", "in", "zu",
+        "ein", "eine", "einer", "einen", "von", "mit", "für", "auf", "nicht",
+        "sich", "sein", "aber", "mehr", "wie", "dieser", "diese", "dieses",
+        "sind", "war", "waren", "wo", "wann", "warum", "weil", "über",
+        "auch", "bis", "seit", "du", "sie", "er", "wir", "ich",
+    }),
+    "it": frozenset({
+        "il", "la", "lo", "i", "gli", "le", "di", "del", "della", "dei",
+        "e", "che", "in", "un", "una", "è", "per", "con", "non", "si",
+        "suo", "sua", "ma", "più", "come", "questo", "questa", "questi",
+        "queste", "sono", "era", "essere", "dove", "quando", "come",
+        "perché", "anche", "fino", "da", "voi", "tu", "noi",
+    }),
+}
+
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÿ]+", re.UNICODE)
+
+
+def _script_vote(text: str) -> Optional[Tuple[str, float]]:
+    """Count characters by script and return dominant non-Latin script.
+
+    Returns ``(lang, confidence)`` when a single non-Latin script accounts
+    for at least ``_SCRIPT_DOMINANCE_RATIO`` of alphabetic characters,
+    else ``None``. Confidence scales from the ratio threshold up to 1.0.
+    """
+    counts: dict[str, int] = {}
+    total_alpha = 0
+    for ch in text:
+        if not ch.isalpha():
+            continue
+        total_alpha += 1
+        cp = ord(ch)
+        for lang, ranges in _SCRIPT_RANGES.items():
+            for lo, hi in ranges:
+                if lo <= cp <= hi:
+                    counts[lang] = counts.get(lang, 0) + 1
+                    break
+
+    if total_alpha < _MIN_ALPHA_CHARS or not counts:
+        return None
+
+    lang, hits = max(counts.items(), key=lambda kv: kv[1])
+    ratio = hits / total_alpha
+    if ratio < _SCRIPT_DOMINANCE_RATIO:
+        return None
+    confidence = min(1.0, 0.5 + ratio * 0.5)
+    return (lang, confidence)
+
+
+def _strip_accents(word: str) -> str:
+    """NFKD-normalize then drop combining marks so 'está' matches 'esta'."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", word)
+        if not unicodedata.combining(c)
+    )
+
+
+def _function_word_vote(text: str) -> Optional[Tuple[str, float]]:
+    """Score Latin-script text against per-language function-word sets.
+
+    Returns ``(lang, confidence)`` when one language wins with enough
+    absolute hits AND a margin over the runner-up, else ``None``.
+    """
+    tokens = [w.lower() for w in _WORD_RE.findall(text)]
+    if len(tokens) < 3:
+        return None
+
+    scores: dict[str, int] = {lang: 0 for lang in _FUNCTION_WORDS}
+    for tok in tokens:
+        for lang, fw in _FUNCTION_WORDS.items():
+            if tok in fw:
+                scores[lang] += 1
+        stripped = _strip_accents(tok)
+        if stripped != tok:
+            for lang, fw in _FUNCTION_WORDS.items():
+                if stripped in fw:
+                    scores[lang] += 1
+
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    top_lang, top = ranked[0]
+    runner = ranked[1][1] if len(ranked) > 1 else 0
+
+    if top < 2:
+        return None
+    margin = top - runner
+    if margin < 1 and top < 4:
+        return None
+
+    denom = top + runner if (top + runner) > 0 else 1
+    confidence = min(1.0, 0.55 + (margin / denom) * 0.45)
+    return (top_lang, confidence)
+
+
+def detect(text: str) -> Tuple[Optional[str], float]:
+    """Detect the language of ``text``.
+
+    Returns ``(iso_code, confidence)`` when a language is identifiable
+    with non-trivial confidence, else ``(None, 0.0)``. Confidence is in
+    ``[0.0, 1.0]``; typical thresholds are 0.6–0.7.
+    """
+    if not text or not text.strip():
+        return (None, 0.0)
+
+    sv = _script_vote(text)
+    if sv is not None:
+        return sv
+
+    fv = _function_word_vote(text)
+    if fv is not None:
+        return fv
+
+    return (None, 0.0)
+
+
+def format_respond_in(lang: str) -> str:
+    """Return the canonical ``[RESPOND IN: <lang>]`` prefix line.
+
+    One-line prefix followed by a blank line, intended to be prepended
+    to the user's message before it reaches the agent. The trailing
+    newlines keep the hint visually distinct from the user text.
+    """
+    return f"[RESPOND IN: {lang}]\n\n"
+
+
+def maybe_prefix(
+    text: str, min_confidence: float = 0.65
+) -> Tuple[str, Optional[str]]:
+    """Prepend ``[RESPOND IN: <lang>]`` to ``text`` when detection is confident.
+
+    Returns ``(possibly_prefixed_text, detected_lang)``. When confidence
+    is below ``min_confidence`` or no language was detected, the text is
+    returned unchanged and ``detected_lang`` is ``None``.
+    """
+    lang, conf = detect(text)
+    if lang is None or conf < min_confidence:
+        return (text, None)
+    return (format_respond_in(lang) + text, lang)
+
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def apply_hint_if_enabled(user_message: str) -> str:
+    """Env-gated pre-processor: prepend ``[RESPOND IN: <lang>]`` in place.
+
+    Default behavior is unchanged (returns ``user_message`` as-is).
+    Set ``HERMES_LANG_HINT_ENABLED=true`` (typically in a per-profile
+    ``.env``) to enable deterministic language-mirror reinforcement.
+    Minimum detection confidence is tunable via
+    ``HERMES_LANG_HINT_MIN_CONFIDENCE`` (default 0.65).
+
+    Skips cleanly in safe cases:
+    - Env flag off (default).
+    - Message is empty / whitespace.
+    - Message already carries a ``[RESPOND IN:`` prefix.
+    - Detection below confidence threshold.
+    - Any exception during detection (the hint is belt-and-suspenders;
+      it must never fail the turn).
+    """
+    if os.getenv("HERMES_LANG_HINT_ENABLED", "").strip().lower() not in _TRUTHY:
+        return user_message
+    if not user_message or not user_message.strip():
+        return user_message
+    if user_message.lstrip().startswith("[RESPOND IN:"):
+        return user_message
+    try:
+        raw = os.getenv("HERMES_LANG_HINT_MIN_CONFIDENCE", "0.65")
+        try:
+            min_conf = float(raw)
+        except ValueError:
+            min_conf = 0.65
+        prefixed, lang = maybe_prefix(user_message, min_confidence=min_conf)
+        if lang is not None:
+            logger.debug("language hint applied: lang=%s", lang)
+        return prefixed
+    except Exception as exc:
+        logger.warning(
+            "language hint failed, passing message through: %s", exc
+        )
+        return user_message

--- a/agent/language_hint.py
+++ b/agent/language_hint.py
@@ -262,7 +262,7 @@ def apply_hint_if_enabled(user_message: str) -> str:
             min_conf = 0.65
         prefixed, lang = maybe_prefix(user_message, min_confidence=min_conf)
         if lang is not None:
-            logger.debug("language hint applied: lang=%s", lang)
+            logger.info("language hint applied: lang=%s", lang)
         return prefixed
     except Exception as exc:
         logger.warning(

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -17,6 +17,45 @@ Kill-switches (env vars):
 - ``HERMES_TS_DISABLED=true`` — completely disables TS; returns None.
 - ``HERMES_TS_DRY_RUN=true`` — samples and logs but does not route or
   mutate state; returns None (falls through to primary).
+
+Configuration example (``config.yaml`` ``smart_model_routing`` section)::
+
+    smart_model_routing:
+      mode: thompson_sampling
+      thompson_sampling:
+        # Persistent state file (default: ~/.hermes/ts_hermes_mds.json)
+        # state_path: /path/to/ts_state.json
+        arms:
+          - name: fireworks-glm5
+            provider: fireworks
+            model: accounts/fireworks/models/glm-5
+            api_key_env: FIREWORKS_API_KEY   # optional; resolved via env
+            base_url: https://api.fireworks.ai/inference/v1  # optional
+          - name: anthropic-sonnet
+            provider: anthropic
+            model: claude-sonnet-4-6
+            api_key_env: ANTHROPIC_API_KEY
+          - name: qwen3-235b
+            provider: together
+            model: Qwen/Qwen3-235B-A22B-Instruct-2507-tput
+            api_key_env: TOGETHER_API_KEY
+
+State file schema (``ts_hermes_mds.json``)::
+
+    {
+      "arms": {
+        "fireworks-glm5": {"a": 1.0, "b": 1.0, "wins": 0, "losses": 0, "last_updated": ""},
+        "anthropic-sonnet": {"a": 1.0, "b": 1.0, "wins": 0, "losses": 0, "last_updated": ""}
+      },
+      "version": 1
+    }
+
+Arm resolution: when TS picks an arm, the returned route dict has the exact
+shape the gateway expects: ``{model, runtime, label, signature}``.  Provider
+credentials are resolved via ``resolve_runtime_provider``.  If credential
+resolution fails for the chosen arm (missing API key, no custom_providers
+entry), the function logs a warning and returns ``None`` so the gateway falls
+back to the primary model.
 """
 
 from __future__ import annotations

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -293,6 +293,8 @@ def choose_thompson_sampling_route(
             runtime.get("command"),
             tuple(runtime.get("args") or ()),
         ),
+        "arm_key": chosen_key,
+        "state_path": str(state_path),
     }
 
 
@@ -316,6 +318,8 @@ def resolve_turn_route(
                 "runtime": route["runtime"],
                 "label": route["label"],
                 "signature": route["signature"],
+                "arm_key": route.get("arm_key"),
+                "state_path": route.get("state_path"),
             }
         return _primary_route(primary)
 

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,12 +1,35 @@
-"""Helpers for optional cheap-vs-strong model routing."""
+"""Helpers for optional cheap-vs-strong model routing.
+
+Supports two routing modes (selected via ``routing_config.mode``):
+
+- ``cheap_model`` (or absent) — keyword-based routing for simple turns.
+- ``thompson_sampling`` — Beta-Bernoulli bandit across a model pool.
+
+Thompson Sampling mode samples one model per user turn from a configurable
+pool of arms.  The sampled model is then ``turn-sticky``: the gateway caches
+it in ``AIAgent.model`` for the remainder of the turn so every LLM call
+within that turn uses the same model.  Outcomes (success/failure) are
+recorded back to a persistent JSON state file so the Beta posteriors
+converge toward the true best arm over time.
+
+Kill-switches (env vars):
+
+- ``HERMES_TS_DISABLED=true`` — completely disables TS; returns None.
+- ``HERMES_TS_DRY_RUN=true`` — samples and logs but does not route or
+  mutate state; returns None (falls through to primary).
+"""
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
 
 _COMPLEX_KEYWORDS = {
     "debug",
@@ -59,7 +82,9 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
-def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def choose_cheap_model_route(
+    user_message: str, routing_config: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
     """Return the configured cheap-model route when a message looks simple.
 
     Conservative by design: if the message has signs of code/tool/debugging/
@@ -107,34 +132,157 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     return route
 
 
-def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]) -> Dict[str, Any]:
+def _primary_route(primary: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "model": primary.get("model"),
+        "runtime": {
+            "api_key": primary.get("api_key"),
+            "base_url": primary.get("base_url"),
+            "provider": primary.get("provider"),
+            "api_mode": primary.get("api_mode"),
+            "command": primary.get("command"),
+            "args": list(primary.get("args") or []),
+            "credential_pool": primary.get("credential_pool"),
+        },
+        "label": None,
+        "signature": (
+            primary.get("model"),
+            primary.get("provider"),
+            primary.get("base_url"),
+            primary.get("api_mode"),
+            primary.get("command"),
+            tuple(primary.get("args") or ()),
+        ),
+    }
+
+
+def choose_thompson_sampling_route(
+    user_message: str,
+    routing_config: Optional[Dict[str, Any]],
+    primary: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return a TS-sampled route, or None if TS is disabled/misconfigured.
+
+    Honors kill-switches:
+      - env HERMES_TS_DISABLED=true → returns None (fall through to primary).
+      - env HERMES_TS_DRY_RUN=true → samples + logs but returns None.
+
+    Each arm is a dict with keys: name, provider, model, api_key (optional,
+    resolves via env by default), base_url (optional), api_mode (optional).
+    """
+    if os.getenv("HERMES_TS_DISABLED", "").strip().lower() in ("true", "1", "yes"):
+        return None
+
+    cfg = routing_config or {}
+    ts_cfg = cfg.get("thompson_sampling") or {}
+    arms = ts_cfg.get("arms") or []
+    if not isinstance(arms, list) or len(arms) < 2:
+        return None
+
+    arm_keys = [str(a.get("name") or a.get("model") or "") for a in arms]
+    if not all(arm_keys):
+        return None
+
+    from hermes_constants import get_hermes_home
+
+    state_path = Path(
+        ts_cfg.get("state_path") or str(get_hermes_home() / "ts_hermes_mds.json")
+    )
+
+    from agent.ts_state import thompson_sample
+
+    dry_run = os.getenv("HERMES_TS_DRY_RUN", "").strip().lower() in ("true", "1", "yes")
+
+    chosen_key = thompson_sample(arm_keys, state_path)
+
+    if dry_run:
+        logger.info("TS dry run: sampled %s but not routing", chosen_key)
+        return None
+
+    chosen_arm = None
+    for arm in arms:
+        key = str(arm.get("name") or arm.get("model") or "")
+        if key == chosen_key:
+            chosen_arm = arm
+            break
+    if not chosen_arm:
+        return None
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    explicit_api_key = None
+    api_key_env = str(chosen_arm.get("api_key_env") or "").strip()
+    if api_key_env:
+        explicit_api_key = os.getenv(api_key_env) or None
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=chosen_arm.get("provider"),
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=chosen_arm.get("base_url"),
+        )
+    except Exception:
+        logger.warning(
+            "TS arm %s: credential resolution failed, falling back to primary",
+            chosen_key,
+        )
+        return None
+
+    if not runtime.get("api_key"):
+        logger.warning(
+            "TS arm %s: no api_key resolved, falling back to primary", chosen_key
+        )
+        return None
+
+    return {
+        "model": chosen_arm.get("model"),
+        "runtime": {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+        },
+        "label": f"thompson sampling → {chosen_arm.get('model')} ({runtime.get('provider')})",
+        "signature": (
+            chosen_arm.get("model"),
+            runtime.get("provider"),
+            runtime.get("base_url"),
+            runtime.get("api_mode"),
+            runtime.get("command"),
+            tuple(runtime.get("args") or ()),
+        ),
+    }
+
+
+def resolve_turn_route(
+    user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]
+) -> Dict[str, Any]:
     """Resolve the effective model/runtime for one turn.
 
     Returns a dict with model/runtime/signature/label fields.
+    Dispatches on ``routing_config.mode``:
+      - ``"thompson_sampling"`` → ``choose_thompson_sampling_route``
+      - ``"cheap_model"`` or absent → ``choose_cheap_model_route``
     """
+    mode = (routing_config or {}).get("mode", "cheap_model")
+
+    if mode == "thompson_sampling":
+        route = choose_thompson_sampling_route(user_message, routing_config, primary)
+        if route:
+            return {
+                "model": route["model"],
+                "runtime": route["runtime"],
+                "label": route["label"],
+                "signature": route["signature"],
+            }
+        return _primary_route(primary)
+
     route = choose_cheap_model_route(user_message, routing_config)
     if not route:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return _primary_route(primary)
 
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -150,27 +298,7 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             explicit_base_url=route.get("base_url"),
         )
     except Exception:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return _primary_route(primary)
 
     return {
         "model": route.get("model"),

--- a/agent/ts_state.py
+++ b/agent/ts_state.py
@@ -1,0 +1,105 @@
+"""Beta-Bernoulli Thompson Sampling state store for model routing.
+
+Schema (JSON file at ``<path>``):
+::
+
+    {
+      "arms": {
+        "anthropic:claude-sonnet-4-6": {"a": 1.0, "b": 1.0, "wins": 0, "losses": 0, "last_updated": "2026-04-17T21:00:00Z"},
+        ...
+      },
+      "version": 1
+    }
+
+Invariants:
+- ``a`` and ``b`` are Beta-distribution shape parameters (prior: Beta(1,1) = uniform).
+- ``wins`` / ``losses`` are integer counts of observed outcomes.
+- ``a = 1 + wins``, ``b = 1 + losses`` at all times.
+- ``last_updated`` is ISO-8601 with trailing ``Z``.
+- File locking uses ``fcntl.flock`` on a sidecar ``<path>.lock`` file (POSIX only).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_ARM_DEFAULT = {"a": 1.0, "b": 1.0, "wins": 0, "losses": 0}
+
+
+def load_state(path: Path, arm_keys: Optional[list[str]] = None) -> dict:
+    """Read state JSON from *path*. Returns ``{}`` when file is missing.
+
+    If *arm_keys* is given, any key not already present in ``arms`` is
+    auto-initialised with the default prior.
+    """
+    try:
+        with open(path, "r") as f:
+            state = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        state = {"arms": {}, "version": 1}
+    if "arms" not in state or not isinstance(state["arms"], dict):
+        state["arms"] = {}
+    if arm_keys:
+        for key in arm_keys:
+            if key not in state["arms"]:
+                state["arms"][key] = dict(_ARM_DEFAULT, last_updated="")
+    return state
+
+
+def _acquire_lock(path: Path):
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_fd = open(lock_path, "w")
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    return lock_fd
+
+
+def _release_lock(lock_fd):
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        lock_fd.close()
+
+
+def thompson_sample(
+    arm_keys: list[str], path: Path, rng: Optional[random.Random] = None
+) -> str:
+    """Sample one arm via Beta(a, b) per arm; return the arm_key with the highest draw.
+
+    *rng* is optional — inject a ``random.Random`` for deterministic testing.
+    """
+    state = load_state(path, arm_keys=arm_keys)
+    best_key = arm_keys[0]
+    best_val = -1.0
+    _betavariate = rng.betavariate if rng else random.betavariate
+    for key in arm_keys:
+        arm = state["arms"].get(key, _ARM_DEFAULT)
+        sample = _betavariate(arm["a"], arm["b"])
+        if sample > best_val:
+            best_val = sample
+            best_key = key
+    return best_key
+
+
+def record_outcome(arm_key: str, success: bool, path: Path) -> None:
+    """Increment a/b and wins/losses for *arm_key*, persist to disk with flock."""
+    lock_fd = _acquire_lock(path)
+    try:
+        state = load_state(path, arm_keys=[arm_key])
+        arm = state["arms"][arm_key]
+        if success:
+            arm["a"] += 1.0
+            arm["wins"] += 1
+        else:
+            arm["b"] += 1.0
+            arm["losses"] += 1
+        arm["last_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(state, f, indent=2)
+    finally:
+        _release_lock(lock_fd)

--- a/agent/ts_state.py
+++ b/agent/ts_state.py
@@ -103,3 +103,26 @@ def record_outcome(arm_key: str, success: bool, path: Path) -> None:
             json.dump(state, f, indent=2)
     finally:
         _release_lock(lock_fd)
+
+
+def classify_outcome(result: Optional[dict]) -> bool:
+    """Map a ``run_conversation`` result dict to a binary TS outcome.
+
+    Returns True (win) when the agent produced a non-empty final_response
+    and did not flag failure. Returns False (loss) when the result is
+    missing, marked failed, compression-exhausted, or has an empty
+    response. Matches the ``ok`` / ``no_response`` taxonomy used by the
+    gateway's turn finaliser.
+    """
+    if not result:
+        return False
+    if result.get("failed"):
+        return False
+    if result.get("compression_exhausted"):
+        return False
+    final = result.get("final_response") or ""
+    if not str(final).strip():
+        return False
+    if result.get("error"):
+        return False
+    return True

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -164,6 +164,19 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
+def _extract_all_recipients(msg) -> list:
+    """Extract all recipient addresses from To, Cc, and Delivered-To headers."""
+    recipients = set()
+    for header in ["To", "Cc", "Delivered-To"]:
+        value = msg.get(header, "")
+        if value:
+            for addr in value.split(","):
+                email = _extract_email_address(addr.strip())
+                if email:
+                    recipients.add(email.lower())
+    return list(recipients)
+
+
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
@@ -376,6 +389,12 @@ class EmailAdapter(BasePlatformAdapter):
 
                     raw_email = msg_data[0][1]
                     msg = email_lib.message_from_bytes(raw_email)
+
+                    # Filter: only process messages addressed to this agent
+                    all_recipients = _extract_all_recipients(msg)
+                    if all_recipients and self._address.lower() not in all_recipients:
+                        logger.debug("[Email] Skipping msg %s - not for %s", uid, self._address)
+                        continue
 
                     sender_raw = msg.get("From", "")
                     sender_addr = _extract_email_address(sender_raw)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1009,6 +1009,33 @@ class GatewayRunner:
         route["request_overrides"] = overrides
         return route
 
+    def _record_turn_outcome(self, turn_route: dict, result) -> None:
+        """Record a Beta-Bernoulli outcome when the turn used a TS arm.
+
+        No-op when ``turn_route`` is from cheap_model mode, the primary
+        route fallback, or any non-TS code path — those never set
+        ``arm_key`` / ``state_path``. Exceptions are swallowed (with a
+        warning) because a failed outcome write must not propagate up
+        into the gateway.
+        """
+        arm_key = turn_route.get("arm_key") if turn_route else None
+        state_path = turn_route.get("state_path") if turn_route else None
+        if not arm_key or not state_path:
+            return
+        try:
+            from agent.ts_state import classify_outcome, record_outcome
+            from pathlib import Path
+
+            success = classify_outcome(result)
+            record_outcome(arm_key, success, Path(state_path))
+            logger.info(
+                "TS outcome recorded: arm=%s success=%s", arm_key, success
+            )
+        except Exception as exc:
+            logger.warning(
+                "TS record_outcome failed for arm=%s: %s", arm_key, exc
+            )
+
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
 
@@ -5879,6 +5906,7 @@ class GatewayRunner:
                     self._cleanup_agent_resources(agent)
 
             result = await self._run_in_executor_with_context(run_sync)
+            self._record_turn_outcome(turn_route, result)
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -6064,6 +6092,7 @@ class GatewayRunner:
                     self._cleanup_agent_resources(agent)
 
             result = await self._run_in_executor_with_context(run_sync)
+            self._record_turn_outcome(turn_route, result)
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -9195,6 +9224,7 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+            self._record_turn_outcome(turn_route, result)
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1009,6 +1009,22 @@ class GatewayRunner:
         route["request_overrides"] = overrides
         return route
 
+    def _maybe_language_hint(self, user_message: str) -> str:
+        """Gateway-side wrapper for ``agent.language_hint.apply_hint_if_enabled``.
+
+        Thin delegate so the three ``run_conversation()`` call sites can
+        pre-process the user message uniformly. Behavior is env-gated
+        and default-off — see ``apply_hint_if_enabled`` docstring.
+        """
+        try:
+            from agent.language_hint import apply_hint_if_enabled
+            return apply_hint_if_enabled(user_message)
+        except Exception as exc:
+            logger.warning(
+                "language hint failed, passing message through: %s", exc
+            )
+            return user_message
+
     def _record_turn_outcome(self, turn_route: dict, result) -> None:
         """Record a Beta-Bernoulli outcome when the turn used a TS arm.
 
@@ -5899,7 +5915,7 @@ class GatewayRunner:
                 )
                 try:
                     return agent.run_conversation(
-                        user_message=prompt,
+                        user_message=self._maybe_language_hint(prompt),
                         task_id=task_id,
                     )
                 finally:
@@ -6084,7 +6100,7 @@ class GatewayRunner:
                 )
                 try:
                     return agent.run_conversation(
-                        user_message=btw_prompt,
+                        user_message=self._maybe_language_hint(btw_prompt),
                         conversation_history=history_snapshot,
                         task_id=task_id,
                     )
@@ -9219,7 +9235,7 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(self._maybe_language_hint(message), conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/run_agent.py
+++ b/run_agent.py
@@ -7098,30 +7098,61 @@ class AIAgent:
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
-        """Strip Codex Responses API fields from tool_calls for strict providers.
+        """Scrub tool_calls so strict OpenAI-compatible APIs accept the replay.
 
-        Providers like Mistral, Fireworks, and other strict OpenAI-compatible APIs
-        validate the Chat Completions schema and reject unknown fields (call_id,
-        response_item_id) with 400 or 422 errors. These fields are preserved in
-        the internal message history — this method only modifies the outgoing
-        API copy.
+        Does two things to the *outgoing API copy* (the in-memory history is
+        untouched so Codex-side fallback still works if the session pivots):
+
+        1. Strip Codex Responses API fields (`call_id`, `response_item_id`).
+           Mistral / Fireworks / Groq reject these with 400/422.
+
+        2. Repair malformed JSON in `function.arguments`. Some models
+           (smaller ones, post-context-compaction states, TS arms that
+           sampled a weak model) emit tool_calls whose `arguments` string
+           is not valid JSON. When that message is later replayed to a
+           strict API, the whole turn 400s:
+
+             Invalid tool call in messages:
+             tool_calls[].function.arguments for function 'X' must be a
+             JSON object string (or an object), got invalid JSON
+
+           Scrub strategy: parse-test each `arguments` string; if it
+           doesn't parse, replace with ``"{}"``. The tool *result* in the
+           next message still carries whatever the tool actually produced,
+           so the model has the semantic information — it just loses
+           visibility of the malformed arg string, which is strictly worse
+           than a hard 400 on every subsequent turn.
 
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
-        Responses API compatibility (e.g. if the session falls back to a
-        Codex provider later).
-
-        Fields stripped: call_id, response_item_id
+        Responses API compatibility.
         """
+        import json as _json
+
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
             return api_msg
         _STRIP_KEYS = {"call_id", "response_item_id"}
-        api_msg["tool_calls"] = [
-            {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
-            if isinstance(tc, dict) else tc
-            for tc in tool_calls
-        ]
+        scrubbed = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                scrubbed.append(tc)
+                continue
+            new_tc = {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
+            fn = new_tc.get("function")
+            if isinstance(fn, dict):
+                args = fn.get("arguments")
+                # Only validate string-form args; dict-form is already an
+                # object and doesn't need JSON parsing.
+                if isinstance(args, str):
+                    try:
+                        _json.loads(args)
+                    except (ValueError, TypeError):
+                        fn_copy = dict(fn)
+                        fn_copy["arguments"] = "{}"
+                        new_tc["function"] = fn_copy
+            scrubbed.append(new_tc)
+        api_msg["tool_calls"] = scrubbed
         return api_msg
 
 

--- a/tests/test_language_hint.py
+++ b/tests/test_language_hint.py
@@ -1,0 +1,239 @@
+"""Tests for agent.language_hint — deterministic language detection + hint."""
+
+import pytest
+
+from agent.language_hint import (
+    apply_hint_if_enabled,
+    detect,
+    format_respond_in,
+    maybe_prefix,
+)
+
+
+class TestDetectLatin:
+    def test_english_full_sentence(self):
+        text = "What is the status of the deployment and why is it failing?"
+        lang, conf = detect(text)
+        assert lang == "en"
+        assert conf >= 0.65
+
+    def test_spanish_with_accents(self):
+        text = "¿Cuál es el estado del despliegue y por qué está fallando?"
+        lang, conf = detect(text)
+        assert lang == "es"
+        assert conf >= 0.65
+
+    def test_spanish_without_accents(self):
+        text = "Cual es el estado del despliegue y por que esta fallando"
+        lang, conf = detect(text)
+        assert lang == "es"
+        assert conf >= 0.65
+
+    def test_portuguese(self):
+        text = "Qual é o status do deploy e por que está falhando?"
+        lang, conf = detect(text)
+        assert lang == "pt"
+        assert conf >= 0.60
+
+    def test_french(self):
+        text = "Quel est le statut du déploiement et pourquoi ne fonctionne pas?"
+        lang, conf = detect(text)
+        assert lang == "fr"
+        assert conf >= 0.65
+
+    def test_german(self):
+        text = "Wie ist der Status der Bereitstellung und warum ist sie fehlgeschlagen?"
+        lang, conf = detect(text)
+        assert lang == "de"
+        assert conf >= 0.65
+
+    def test_italian(self):
+        text = "Qual è lo stato del deployment e perché non funziona?"
+        lang, conf = detect(text)
+        assert lang == "it"
+        assert conf >= 0.60
+
+
+class TestDetectNonLatin:
+    def test_japanese_hiragana_katakana(self):
+        text = "デプロイの状態はどうですか、なぜ失敗していますか？"
+        lang, conf = detect(text)
+        assert lang == "ja"
+        assert conf >= 0.70
+
+    def test_russian_cyrillic(self):
+        text = "Каков статус развертывания и почему оно не работает?"
+        lang, conf = detect(text)
+        assert lang == "ru"
+        assert conf >= 0.70
+
+    def test_arabic(self):
+        text = "ما هي حالة النشر ولماذا يفشل؟ هذا سؤال مهم جدا."
+        lang, conf = detect(text)
+        assert lang == "ar"
+        assert conf >= 0.70
+
+    def test_korean_hangul(self):
+        text = "배포 상태는 어떻고 왜 실패하고 있습니까? 이것은 중요합니다."
+        lang, conf = detect(text)
+        assert lang == "ko"
+        assert conf >= 0.70
+
+    def test_chinese(self):
+        text = "部署的状态如何，为什么失败了？这个问题很重要。"
+        lang, conf = detect(text)
+        assert lang == "zh"
+        assert conf >= 0.70
+
+
+class TestNoDetection:
+    def test_empty_string(self):
+        lang, conf = detect("")
+        assert lang is None
+        assert conf == 0.0
+
+    def test_whitespace_only(self):
+        lang, conf = detect("   \n\t  ")
+        assert lang is None
+        assert conf == 0.0
+
+    def test_too_short(self):
+        lang, conf = detect("ok")
+        assert lang is None
+
+    def test_pure_numbers(self):
+        lang, conf = detect("12345 67890 99.5%")
+        assert lang is None
+
+    def test_pure_punctuation(self):
+        lang, conf = detect("!!! ??? ... ---")
+        assert lang is None
+
+    def test_code_snippet_no_false_positive(self):
+        text = "def foo(x): return x * 2"
+        lang, conf = detect(text)
+        assert (lang, conf) == (None, 0.0) or conf < 0.65
+
+
+class TestFormatRespondIn:
+    def test_basic_format(self):
+        out = format_respond_in("en")
+        assert out.startswith("[RESPOND IN: en]")
+        assert out.endswith("\n\n")
+
+    def test_spanish_format(self):
+        out = format_respond_in("es")
+        assert "[RESPOND IN: es]" in out
+
+
+class TestMaybePrefix:
+    def test_prefixes_confident_english(self):
+        text = "What is the status of the deployment and the current errors?"
+        prefixed, lang = maybe_prefix(text)
+        assert lang == "en"
+        assert prefixed.startswith("[RESPOND IN: en]")
+        assert text in prefixed
+
+    def test_prefixes_confident_spanish(self):
+        text = "¿Cuál es el estado del despliegue y cuáles son los errores actuales?"
+        prefixed, lang = maybe_prefix(text)
+        assert lang == "es"
+        assert prefixed.startswith("[RESPOND IN: es]")
+
+    def test_skips_low_confidence(self):
+        text = "ok"
+        prefixed, lang = maybe_prefix(text, min_confidence=0.65)
+        assert lang is None
+        assert prefixed == text
+
+    def test_skips_empty(self):
+        prefixed, lang = maybe_prefix("", min_confidence=0.65)
+        assert lang is None
+        assert prefixed == ""
+
+    def test_skips_on_high_threshold_when_confidence_low(self):
+        text = "Quick question"
+        prefixed, lang = maybe_prefix(text, min_confidence=0.95)
+        assert lang is None
+        assert prefixed == text
+
+    def test_preserves_original_text_after_prefix(self):
+        text = "Please summarize the recent deploy logs and errors from today."
+        prefixed, lang = maybe_prefix(text)
+        assert lang == "en"
+        assert prefixed.endswith(text)
+
+
+class TestApplyHintIfEnabled:
+    def test_default_off_passes_through(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LANG_HINT_ENABLED", raising=False)
+        text = "¿Cuál es el estado del despliegue y cuáles son los errores?"
+        out = apply_hint_if_enabled(text)
+        assert out == text
+
+    def test_enabled_applies_spanish(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        text = "¿Cuál es el estado del despliegue y cuáles son los errores?"
+        out = apply_hint_if_enabled(text)
+        assert out.startswith("[RESPOND IN: es]")
+        assert text in out
+
+    def test_enabled_applies_english(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "1")
+        text = "What is the status of the deployment and why is it failing?"
+        out = apply_hint_if_enabled(text)
+        assert out.startswith("[RESPOND IN: en]")
+
+    def test_enabled_but_low_confidence_passes_through(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "yes")
+        text = "ok"
+        out = apply_hint_if_enabled(text)
+        assert out == text
+
+    def test_already_prefixed_is_not_double_prefixed(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        text = "[RESPOND IN: en]\n\nWhat is the deploy status please?"
+        out = apply_hint_if_enabled(text)
+        assert out == text
+        assert out.count("[RESPOND IN:") == 1
+
+    def test_empty_string_passes_through_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        assert apply_hint_if_enabled("") == ""
+
+    def test_whitespace_only_passes_through_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        assert apply_hint_if_enabled("   \n\t  ") == "   \n\t  "
+
+    def test_truthy_variants_all_enable(self, monkeypatch):
+        text = "What is the status of the deployment and errors today?"
+        for val in ("1", "true", "TRUE", "yes", "YES", "on", " on "):
+            monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", val)
+            out = apply_hint_if_enabled(text)
+            assert out.startswith("[RESPOND IN: en]"), f"val={val!r} did not enable"
+
+    def test_falsy_variants_stay_off(self, monkeypatch):
+        text = "What is the status of the deployment and errors today?"
+        for val in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", val)
+            out = apply_hint_if_enabled(text)
+            assert out == text, f"val={val!r} unexpectedly enabled"
+
+    def test_high_threshold_skips_marginal_detection(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        monkeypatch.setenv("HERMES_LANG_HINT_MIN_CONFIDENCE", "0.95")
+        # Spanish sample that scores in the ~0.82-0.85 range — above
+        # the default 0.65 threshold but below this test's 0.95 floor.
+        text = "el coche es grande y la casa roja"
+        out = apply_hint_if_enabled(text)
+        assert out == text, (
+            "a high HERMES_LANG_HINT_MIN_CONFIDENCE should gate moderate-"
+            "confidence detections out"
+        )
+
+    def test_bad_threshold_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LANG_HINT_ENABLED", "true")
+        monkeypatch.setenv("HERMES_LANG_HINT_MIN_CONFIDENCE", "not-a-number")
+        text = "What is the status of the deployment and errors today?"
+        out = apply_hint_if_enabled(text)
+        assert out.startswith("[RESPOND IN: en]")

--- a/tests/test_smart_model_routing_ts.py
+++ b/tests/test_smart_model_routing_ts.py
@@ -1,0 +1,158 @@
+"""Tests for agent.smart_model_routing — Thompson Sampling mode."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.smart_model_routing import choose_thompson_sampling_route, resolve_turn_route
+
+
+@pytest.fixture
+def state_path(tmp_path):
+    return tmp_path / "ts_state.json"
+
+
+@pytest.fixture
+def ts_config(state_path):
+    return {
+        "mode": "thompson_sampling",
+        "thompson_sampling": {
+            "state_path": str(state_path),
+            "arms": [
+                {
+                    "name": "arm_a",
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key_env": "OPENAI_API_KEY",
+                },
+                {
+                    "name": "arm_b",
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "api_key_env": "ANTHROPIC_API_KEY",
+                },
+            ],
+        },
+    }
+
+
+PRIMARY = {
+    "model": "primary-model",
+    "api_key": "pk-1",
+    "base_url": "https://primary.example.com",
+    "provider": "primary",
+    "api_mode": "chat",
+    "command": None,
+    "args": [],
+    "credential_pool": None,
+}
+
+
+class TestChooseThompsonSamplingRoute:
+    def test_ts_disabled_env_returns_none(self, ts_config):
+        with patch.dict(os.environ, {"HERMES_TS_DISABLED": "true"}):
+            result = choose_thompson_sampling_route("hello", ts_config, PRIMARY)
+        assert result is None
+
+    def test_ts_dry_run_env_returns_none_after_sampling(self, ts_config, state_path):
+        from agent.ts_state import load_state
+
+        state_before = load_state(state_path, arm_keys=["arm_a", "arm_b"])
+        with patch.dict(os.environ, {"HERMES_TS_DRY_RUN": "true"}):
+            result = choose_thompson_sampling_route("hello", ts_config, PRIMARY)
+        assert result is None
+        state_after = load_state(state_path, arm_keys=["arm_a", "arm_b"])
+        for arm in ("arm_a", "arm_b"):
+            assert state_after["arms"][arm]["last_updated"] == state_before["arms"].get(
+                arm, {}
+            ).get("last_updated", "")
+
+    def test_missing_arm_credentials_returns_none(self, state_path):
+        config = {
+            "mode": "thompson_sampling",
+            "thompson_sampling": {
+                "state_path": str(state_path),
+                "arms": [
+                    {
+                        "name": "no_creds",
+                        "provider": "nonexistent_provider",
+                        "model": "fake-model",
+                    },
+                ],
+            },
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=Exception("no provider"),
+        ):
+            result = choose_thompson_sampling_route("hello", config, PRIMARY)
+        assert result is None
+
+
+class TestResolveTurnRoute:
+    def test_turn_stickiness_simulation(self, ts_config, state_path):
+        runtime_stub = {
+            "api_key": "sk-test",
+            "base_url": "https://api.openai.com/v1",
+            "provider": "openai",
+            "api_mode": "chat",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime_stub,
+            ),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}),
+        ):
+            route = resolve_turn_route("hello", ts_config, PRIMARY)
+        chosen_model = route["model"]
+        for _ in range(5):
+            assert route["model"] == chosen_model
+
+    def test_ts_mode_dispatches_to_ts(self, ts_config, state_path):
+        runtime_stub = {
+            "api_key": "sk-test",
+            "base_url": "https://api.openai.com/v1",
+            "provider": "openai",
+            "api_mode": "chat",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime_stub,
+            ),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}),
+            patch("agent.ts_state.thompson_sample", return_value="arm_a"),
+        ):
+            route = resolve_turn_route("hello", ts_config, PRIMARY)
+        assert route["model"] == "gpt-4o-mini"
+        assert "thompson sampling" in (route["label"] or "")
+
+    def test_cheap_model_mode_unchanged(self):
+        config = {
+            "mode": "cheap_model",
+            "enabled": True,
+            "cheap_model": {"provider": "openai", "model": "gpt-4o-mini"},
+        }
+        with patch("agent.smart_model_routing.choose_cheap_model_route") as mock_cmr:
+            mock_cmr.return_value = None
+            resolve_turn_route("hello", config, PRIMARY)
+        mock_cmr.assert_called_once_with("hello", config)
+
+    def test_no_mode_defaults_to_cheap_model(self):
+        config = {
+            "enabled": True,
+            "cheap_model": {"provider": "openai", "model": "gpt-4o-mini"},
+        }
+        with patch("agent.smart_model_routing.choose_cheap_model_route") as mock_cmr:
+            mock_cmr.return_value = None
+            resolve_turn_route("hello", config, PRIMARY)
+        mock_cmr.assert_called_once_with("hello", config)

--- a/tests/test_smart_model_routing_ts.py
+++ b/tests/test_smart_model_routing_ts.py
@@ -136,6 +136,67 @@ class TestResolveTurnRoute:
         assert route["model"] == "gpt-4o-mini"
         assert "thompson sampling" in (route["label"] or "")
 
+    def test_ts_route_exposes_arm_key_and_state_path(self, ts_config, state_path):
+        runtime_stub = {
+            "api_key": "sk-test",
+            "base_url": "https://api.openai.com/v1",
+            "provider": "openai",
+            "api_mode": "chat",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime_stub,
+            ),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}),
+            patch("agent.ts_state.thompson_sample", return_value="arm_a"),
+        ):
+            route = resolve_turn_route("hello", ts_config, PRIMARY)
+        assert route["arm_key"] == "arm_a"
+        assert route["state_path"] == str(state_path)
+
+    def test_primary_fallback_has_no_arm_key(self):
+        config = {
+            "mode": "thompson_sampling",
+            "thompson_sampling": {"arms": []},  # empty → TS returns None → primary
+        }
+        route = resolve_turn_route("hello", config, PRIMARY)
+        assert route.get("arm_key") is None
+        assert route.get("state_path") is None
+
+    def test_ts_record_outcome_persists_arm_state(
+        self, ts_config, state_path
+    ):
+        from agent.ts_state import load_state, record_outcome
+
+        runtime_stub = {
+            "api_key": "sk-test",
+            "base_url": "https://api.openai.com/v1",
+            "provider": "openai",
+            "api_mode": "chat",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=runtime_stub,
+            ),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}),
+            patch("agent.ts_state.thompson_sample", return_value="arm_b"),
+        ):
+            route = resolve_turn_route("hello", ts_config, PRIMARY)
+        from pathlib import Path as _P
+
+        record_outcome(route["arm_key"], True, _P(route["state_path"]))
+        state = load_state(_P(route["state_path"]), arm_keys=["arm_b"])
+        assert state["arms"]["arm_b"]["wins"] == 1
+        assert state["arms"]["arm_b"]["a"] == 2.0
+
     def test_cheap_model_mode_unchanged(self):
         config = {
             "mode": "cheap_model",

--- a/tests/test_ts_state.py
+++ b/tests/test_ts_state.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from agent.ts_state import load_state, record_outcome, thompson_sample
+from agent.ts_state import classify_outcome, load_state, record_outcome, thompson_sample
 
 
 @pytest.fixture
@@ -52,3 +52,31 @@ class TestThompsonSample:
         fresh = load_state(state_path)
         assert fresh["arms"]["x"]["wins"] == 1
         assert fresh["arms"]["y"]["losses"] == 1
+
+
+class TestClassifyOutcome:
+    def test_none_is_loss(self):
+        assert classify_outcome(None) is False
+
+    def test_empty_dict_is_loss(self):
+        assert classify_outcome({}) is False
+
+    def test_non_empty_final_response_is_win(self):
+        assert classify_outcome({"final_response": "hello"}) is True
+
+    def test_whitespace_only_final_response_is_loss(self):
+        assert classify_outcome({"final_response": "   \n "}) is False
+
+    def test_failed_flag_is_loss(self):
+        assert classify_outcome({"final_response": "hi", "failed": True}) is False
+
+    def test_compression_exhausted_is_loss(self):
+        assert (
+            classify_outcome({"final_response": "hi", "compression_exhausted": True})
+            is False
+        )
+
+    def test_error_field_is_loss(self):
+        assert (
+            classify_outcome({"final_response": "hi", "error": "boom"}) is False
+        )

--- a/tests/test_ts_state.py
+++ b/tests/test_ts_state.py
@@ -1,0 +1,54 @@
+"""Tests for agent.ts_state — Beta-Bernoulli Thompson Sampling store."""
+
+import json
+import math
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from agent.ts_state import load_state, record_outcome, thompson_sample
+
+
+@pytest.fixture
+def state_path(tmp_path):
+    return tmp_path / "ts_state.json"
+
+
+class TestThompsonSample:
+    def test_flat_prior_uniform_sampling(self, state_path):
+        rng = __import__("random").Random(42)
+        arms = ["arm_a", "arm_b", "arm_c"]
+        counts = {k: 0 for k in arms}
+        n = 300
+        for _ in range(n):
+            chosen = thompson_sample(arms, state_path, rng=rng)
+            counts[chosen] += 1
+        expected = n / len(arms)
+        std = math.sqrt(expected * (1 - 1 / len(arms)))
+        three_sigma = 3 * std
+        for arm in arms:
+            assert expected - three_sigma <= counts[arm] <= expected + three_sigma, (
+                f"{arm} count {counts[arm]} outside 3-sigma [{expected - three_sigma:.0f}, {expected + three_sigma:.0f}]"
+            )
+
+    def test_record_outcome_updates_counters(self, state_path):
+        arm = "test_arm"
+        for _ in range(5):
+            record_outcome(arm, True, state_path)
+        for _ in range(3):
+            record_outcome(arm, False, state_path)
+        state = load_state(state_path, arm_keys=[arm])
+        entry = state["arms"][arm]
+        assert entry["a"] == 6.0
+        assert entry["b"] == 4.0
+        assert entry["wins"] == 5
+        assert entry["losses"] == 3
+        datetime.strptime(entry["last_updated"], "%Y-%m-%dT%H:%M:%SZ")
+
+    def test_state_persistence_roundtrip(self, state_path):
+        record_outcome("x", True, state_path)
+        record_outcome("y", False, state_path)
+        fresh = load_state(state_path)
+        assert fresh["arms"]["x"]["wins"] == 1
+        assert fresh["arms"]["y"]["losses"] == 1

--- a/tools/consult_colleague_tool.py
+++ b/tools/consult_colleague_tool.py
@@ -1,0 +1,148 @@
+"""consult_colleague tool — thin wrapper that shells to another MD via hermes CLI.
+
+This is the minimum-viable version. It matches the signature the LLMs already
+naturally emit (agent + query) so the tool call resolves cleanly instead of
+dying as a malformed JSON fragment.
+
+When the full 2026-04-18 spec ships (#724 — routing matrix, depth guard,
+audit DB, daily cap), this wrapper is replaced with no caller-side change.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_VALID_PROFILES = {"scarlett", "christopher", "hilary", "elon", "eva"}
+_PROFILE_ALIASES = {"hillary": "hilary"}  # one-L vs two-L typo accommodation
+
+
+CONSULT_COLLEAGUE_SCHEMA = {
+    "name": "consult_colleague",
+    "description": (
+        "Ask another Toryx Managing Director a single focused question and "
+        "return their answer. Same-host subprocess (no email, no network). "
+        "Use for cross-desk coordination when a question falls outside your "
+        "domain and a peer has a relevant skill. Colleague must be one of: "
+        "scarlett, christopher, hilary, elon, eva. The response is the "
+        "colleague's final reply as a single string; integrate it into your "
+        "own answer and credit them (e.g. 'Christopher says: …'). Do not "
+        "chain multiple consults — call this once per question."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Which colleague to consult. One of: "
+                    "scarlett, christopher, hilary, elon, eva."
+                ),
+                "enum": ["scarlett", "christopher", "hilary", "elon", "eva", "hillary"],
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "The full, self-contained question. The colleague will "
+                    "NOT see the surrounding conversation, so include any "
+                    "needed context in the question itself."
+                ),
+            },
+        },
+        "required": ["agent", "query"],
+    },
+}
+
+
+def consult_colleague(agent: str, query: str, **_: Any) -> Dict[str, Any]:
+    agent = (agent or "").strip().lower()
+    agent = _PROFILE_ALIASES.get(agent, agent)
+    if agent not in _VALID_PROFILES:
+        return tool_error(
+            f"Unknown colleague '{agent}'. Must be one of: "
+            + ", ".join(sorted(_VALID_PROFILES))
+        )
+    if not query or not query.strip():
+        return tool_error("query must be a non-empty string")
+
+    caller = os.getenv("HERMES_PROFILE", "unknown")
+    if agent == caller:
+        return tool_error(
+            f"Cannot consult self ('{agent}'). Answer from your own skills instead."
+        )
+
+    # Depth guard — one level only. Prevents A→B→A loops and fan-out.
+    depth = int(os.getenv("HERMES_CONSULT_DEPTH", "0") or "0")
+    if depth >= 1:
+        return tool_error(
+            "consult chain already at max depth (1). Answer from your own "
+            "skills or refuse."
+        )
+
+    env = os.environ.copy()
+    env["HERMES_CONSULT_DEPTH"] = str(depth + 1)
+    env["HERMES_CONSULT_CALLER"] = caller
+
+    hermes_bin = os.getenv(
+        "HERMES_BIN",
+        "/home/luis/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main",
+    ).split()
+
+    cmd = hermes_bin + [
+        "-p", agent, "chat",
+        "-q", f"[Consult from {caller}] {query}",
+        "-Q",
+        "--max-turns", "30",
+    ]
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        return tool_error(
+            f"consult to '{agent}' timed out after 180s. Retry once with a "
+            "tighter question, otherwise refuse and notify the user."
+        )
+    latency_ms = int((time.time() - t0) * 1000)
+
+    answer = (proc.stdout or "").strip()
+    if proc.returncode != 0:
+        return tool_error(
+            f"consult to '{agent}' failed with exit {proc.returncode}; "
+            f"stderr tail: {(proc.stderr or '')[-400:]}"
+        )
+    if not answer:
+        return tool_error(
+            f"'{agent}' returned empty stdout (ran for {latency_ms} ms). "
+            "Retry once; if still empty, refuse."
+        )
+
+    return {
+        "colleague": agent,
+        "answer": answer,
+        "latency_ms": latency_ms,
+        "terminal_status": "ok",
+    }
+
+
+registry.register(
+    name="consult_colleague",
+    toolset="delegation",
+    schema=CONSULT_COLLEAGUE_SCHEMA,
+    handler=lambda args, **kw: consult_colleague(
+        agent=args.get("agent"),
+        query=args.get("query"),
+    ),
+    emoji="🤝",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "consult_colleague",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -187,8 +187,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn subagents (delegate_task) or consult peer MDs (consult_colleague) for cross-desk coordination",
+        "tools": ["delegate_task", "consult_colleague"],
         "includes": []
     },
 


### PR DESCRIPTION
Cherry-picks 10 Toryx-specific commits from `feat/thompson-sampling-routing` onto `main`. This is the #833 integration — avoids pulling the 200+ upstream NousResearch commits that also sit on the feat branch.

## Included (chronological)

| # | SHA (cherry-picked from) | Subject |
|---|---|---|
| 1 | `ecdc876a` | feat(routing): add ts_state Beta-Bernoulli store with file locking + tests |
| 2 | `684acc77` | feat(routing): add thompson_sampling mode to resolve_turn_route + tests |
| 3 | `b7907ff6` | docs(routing): document thompson_sampling mode config, state schema, and arm resolution |
| 4 | `0676c3c7` | feat(routing): wire record_outcome() so TS posteriors actually update |
| 5 | `8c621907` | feat(language): deterministic [RESPOND IN: <lang>] hint module + tests |
| 6 | `d4e726a9` | feat(gateway): wire language_hint.apply_hint_if_enabled at 3 run_conversation call sites |
| 7 | `32019ac2` | chore(language): promote 'hint applied' log from DEBUG to INFO |
| 8 | `17ca0a69` | fix(runtime): repair malformed JSON in tool_call.arguments during replay sanitize |
| 9 | `bdb71ea8` | feat(tools): register consult_colleague — minimal tool binding for cross-MD coordination |
| 10 | `ae53a466` | feat(email): add recipient filtering to prevent cross-agent contamination (#760) |

## Skipped

- `00280b06` (feat(hermes): restore Fish Audio TTS + voice-only reply + SMTP 465 + Groq reasoning guard) — already on main as PR #8, identical patch-id.

## Conflict resolved

`gateway/platforms/email.py` — `EMAIL_IGNORED_SENDERS` blocklist check: main's PR #7 already added the same logic with a richer comment. Kept main's version; dropped the ae53a466 duplicate. ae53a466's actual new feature (recipient filtering via `_extract_all_recipients` + IMAP-side filter) applied cleanly.

## Sanity

- All merge-conflict markers removed (`git grep` clean).
- 3 new modules import cleanly: `agent/ts_state.py`, `agent/language_hint.py`, `tools/consult_colleague_tool.py`.
- Diff: +1420 / -66 across 11 files.

## What's still on `feat/thompson-sampling-routing` after this lands

Only the ~220 upstream NousResearch commits that are for reference, not deployment. The branch can be archived once this PR merges.

Closes #833.